### PR TITLE
mcp_updates

### DIFF
--- a/__tests__/client/client.test.ts
+++ b/__tests__/client/client.test.ts
@@ -29,8 +29,8 @@ describe('BentoClient', () => {
 
       const mockBuffer = {
         from: mock(() => ({
-          toString: () => 'mocked-base64'
-        }))
+          toString: () => 'mocked-base64',
+        })),
       };
       globalScope.Buffer = mockBuffer;
 
@@ -38,8 +38,8 @@ describe('BentoClient', () => {
         ...mockOptions,
         authentication: {
           publishableKey: 'test',
-          secretKey: 'test'
-        }
+          secretKey: 'test',
+        },
       });
 
       const headers = (analytics.V1 as any)._client._headers;
@@ -60,7 +60,7 @@ describe('BentoClient', () => {
       // Test basic ASCII encoding
       // Create a test string that we can predict the base64 output for
       const testStr = 'test:test';
-      const expectedBase64 = 'dGVzdDp0ZXN0';  // 'test:test' in base64
+      const expectedBase64 = 'dGVzdDp0ZXN0'; // 'test:test' in base64
       const result = (analytics.V1 as any)._client._extractHeaders(
         { publishableKey: 'test', secretKey: 'test' },
         'test'
@@ -84,7 +84,9 @@ describe('BentoClient', () => {
           { publishableKey: nonLatin1Str, secretKey: '' },
           'test'
         );
-      }).toThrow("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+      }).toThrow(
+        "'btoa' failed: The string to be encoded contains characters outside of the Latin1 range."
+      );
 
       globalScope.btoa = originalBtoa;
       globalScope.Buffer = originalBuffer;
@@ -104,23 +106,13 @@ describe('BentoClient', () => {
 
     test('handles text/plain error response', async () => {
       const errorMessage = 'Plain text error message';
-      setupMockFetch(
-        { error: errorMessage },
-        500,
-        'text/plain'
-      );
+      setupMockFetch({ error: errorMessage }, 500, 'text/plain');
 
-      expect(analytics.V1.Tags.getTags()).rejects.toThrow(
-        `[500] - ${errorMessage}`
-      );
+      expect(analytics.V1.Tags.getTags()).rejects.toThrow(`[500] - ${errorMessage}`);
     });
 
     test('handles unknown content-type error response', async () => {
-      setupMockFetch(
-        { error: 'Unknown error' },
-        500,
-        'application/unknown'
-      );
+      setupMockFetch({ error: 'Unknown error' }, 500, 'application/unknown');
 
       expect(analytics.V1.Tags.getTags()).rejects.toThrow(
         '[500] - Unknown response from the Bento API.'
@@ -151,8 +143,8 @@ describe('BentoClient', () => {
       const customOptions = {
         ...mockOptions,
         clientOptions: {
-          baseUrl: 'https://custom.api.com'
-        }
+          baseUrl: 'https://custom.api.com',
+        },
       };
       const customAnalytics = new Analytics(customOptions);
       const client = (customAnalytics.V1 as any)._client;
@@ -171,10 +163,10 @@ describe('BentoClient', () => {
             ok: true,
             json: () => Promise.resolve({ data: null }),
             headers: new Headers({
-              'Content-Type': 'application/json'
-            })
+              'Content-Type': 'application/json',
+            }),
           });
-        }
+        },
       }));
 
       await analytics.V1.Forms.getResponses('test-form');
@@ -183,6 +175,40 @@ describe('BentoClient', () => {
       expect(capturedUrl).not.toBeNull();
       const url = new URL(capturedUrl!);
       expect(url.searchParams.get('id')).toBe('test-form');
+      expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
+    });
+
+    test('converts non-string query parameter values to strings', async () => {
+      let capturedUrl: string | null = null;
+
+      // Setup mock that captures the URL
+      mock.module('cross-fetch', () => ({
+        default: (url: string, _options: RequestInit) => {
+          capturedUrl = url;
+          return Promise.resolve({
+            status: 200,
+            ok: true,
+            json: () => Promise.resolve({ data: null }),
+            headers: new Headers({
+              'Content-Type': 'application/json',
+            }),
+          });
+        },
+      }));
+
+      // Test with a parameter that would have a non-string value
+      await analytics.V1.Forms.getResponses('test-form');
+
+      // Verify URL query parameters are properly stringified
+      expect(capturedUrl).not.toBeNull();
+      const url = new URL(capturedUrl!);
+
+      // All query parameters should be strings, not undefined or null
+      expect(typeof url.searchParams.get('site_uuid')).toBe('string');
+      expect(url.searchParams.get('site_uuid')).not.toBe('undefined');
+      expect(url.searchParams.get('site_uuid')).not.toBe('null');
+
+      // Verify site_uuid is properly set
       expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
     });
   });

--- a/__tests__/email-templates/email-templates.test.ts
+++ b/__tests__/email-templates/email-templates.test.ts
@@ -1,0 +1,233 @@
+import { expect, test, describe, beforeEach } from 'bun:test';
+import { Analytics } from '../../src';
+import { mockOptions } from '../helpers/mockClient';
+import { setupMockFetch, lastFetchUrl, lastFetchMethod } from '../helpers/mockFetch';
+import { EntityType } from '../../src/sdk/enums';
+
+describe('BentoEmailTemplates', () => {
+  let analytics: Analytics;
+
+  beforeEach(() => {
+    analytics = new Analytics(mockOptions);
+  });
+
+  describe('getEmailTemplate', () => {
+    test('successfully retrieves an email template by ID', async () => {
+      const mockTemplate = {
+        data: {
+          id: '123',
+          type: EntityType.EMAIL_TEMPLATES,
+          attributes: {
+            name: 'Welcome Email',
+            subject: 'Welcome to our service!',
+            html: '<h1>Welcome!</h1><p>Thank you for signing up.</p>',
+            created_at: '2024-01-01T00:00:00Z',
+            stats: { opened: 100, clicked: 50 },
+          },
+        },
+      };
+
+      setupMockFetch(mockTemplate);
+
+      const result = await analytics.V1.EmailTemplates.getEmailTemplate({ id: 123 });
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('123');
+      expect(result!.attributes.name).toBe('Welcome Email');
+      expect(result!.attributes.subject).toBe('Welcome to our service!');
+      expect(result!.attributes.html).toBe('<h1>Welcome!</h1><p>Thank you for signing up.</p>');
+    });
+
+    test('uses correct endpoint for GET request', async () => {
+      setupMockFetch({ data: { id: '123', type: EntityType.EMAIL_TEMPLATES, attributes: {} } });
+
+      await analytics.V1.EmailTemplates.getEmailTemplate({ id: 456 });
+
+      expect(lastFetchUrl).toContain('/fetch/emails/templates/456');
+      expect(lastFetchMethod).toBe('GET');
+    });
+
+    test('returns null when response is empty object', async () => {
+      setupMockFetch({});
+
+      const result = await analytics.V1.EmailTemplates.getEmailTemplate({ id: 999 });
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when response has no data', async () => {
+      setupMockFetch({ data: null });
+
+      const result = await analytics.V1.EmailTemplates.getEmailTemplate({ id: 999 });
+
+      expect(result).toBeNull();
+    });
+
+    test('returns template with null stats', async () => {
+      const mockTemplate = {
+        data: {
+          id: '789',
+          type: EntityType.EMAIL_TEMPLATES,
+          attributes: {
+            name: 'No Stats Template',
+            subject: 'Test Subject',
+            html: '<p>Test</p>',
+            created_at: '2024-01-01T00:00:00Z',
+            stats: null,
+          },
+        },
+      };
+
+      setupMockFetch(mockTemplate);
+
+      const result = await analytics.V1.EmailTemplates.getEmailTemplate({ id: 789 });
+
+      expect(result).not.toBeNull();
+      expect(result!.attributes.stats).toBeNull();
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(analytics.V1.EmailTemplates.getEmailTemplate({ id: 123 })).rejects.toThrow();
+    });
+  });
+
+  describe('updateEmailTemplate', () => {
+    test('successfully updates email template subject', async () => {
+      const mockUpdatedTemplate = {
+        data: {
+          id: '123',
+          type: EntityType.EMAIL_TEMPLATES,
+          attributes: {
+            name: 'Welcome Email',
+            subject: 'New Subject Line',
+            html: '<h1>Welcome!</h1>',
+            created_at: '2024-01-01T00:00:00Z',
+            stats: null,
+          },
+        },
+      };
+
+      setupMockFetch(mockUpdatedTemplate);
+
+      const result = await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 123,
+        subject: 'New Subject Line',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.attributes.subject).toBe('New Subject Line');
+    });
+
+    test('successfully updates email template HTML', async () => {
+      const mockUpdatedTemplate = {
+        data: {
+          id: '123',
+          type: EntityType.EMAIL_TEMPLATES,
+          attributes: {
+            name: 'Welcome Email',
+            subject: 'Welcome!',
+            html: '<h1>Updated Content</h1>',
+            created_at: '2024-01-01T00:00:00Z',
+            stats: null,
+          },
+        },
+      };
+
+      setupMockFetch(mockUpdatedTemplate);
+
+      const result = await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 123,
+        html: '<h1>Updated Content</h1>',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.attributes.html).toBe('<h1>Updated Content</h1>');
+    });
+
+    test('successfully updates both subject and HTML', async () => {
+      const mockUpdatedTemplate = {
+        data: {
+          id: '123',
+          type: EntityType.EMAIL_TEMPLATES,
+          attributes: {
+            name: 'Welcome Email',
+            subject: 'Brand New Subject',
+            html: '<p>Brand New HTML</p>',
+            created_at: '2024-01-01T00:00:00Z',
+            stats: { opened: 200 },
+          },
+        },
+      };
+
+      setupMockFetch(mockUpdatedTemplate);
+
+      const result = await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 123,
+        subject: 'Brand New Subject',
+        html: '<p>Brand New HTML</p>',
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.attributes.subject).toBe('Brand New Subject');
+      expect(result!.attributes.html).toBe('<p>Brand New HTML</p>');
+    });
+
+    test('uses correct endpoint for PATCH request', async () => {
+      setupMockFetch({ data: { id: '123', type: EntityType.EMAIL_TEMPLATES, attributes: {} } });
+
+      await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 456,
+        subject: 'Test Subject',
+      });
+
+      expect(lastFetchUrl).toContain('/fetch/emails/templates/456');
+      expect(lastFetchMethod).toBe('PATCH');
+    });
+
+    test('returns null when response is empty object', async () => {
+      setupMockFetch({});
+
+      const result = await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 999,
+        subject: 'Test',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when response has no data', async () => {
+      setupMockFetch({ data: null });
+
+      const result = await analytics.V1.EmailTemplates.updateEmailTemplate({
+        id: 999,
+        html: '<p>Test</p>',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(
+        analytics.V1.EmailTemplates.updateEmailTemplate({
+          id: 123,
+          subject: 'Test',
+        })
+      ).rejects.toThrow();
+    });
+
+    test('handles 404 not found error', async () => {
+      setupMockFetch({ error: 'Not Found' }, 404);
+
+      await expect(
+        analytics.V1.EmailTemplates.updateEmailTemplate({
+          id: 999999,
+          subject: 'Test',
+        })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/__tests__/experimental/experimental.test.ts
+++ b/__tests__/experimental/experimental.test.ts
@@ -15,7 +15,7 @@ describe('BentoExperimental', () => {
       setupMockFetch({ valid: true });
 
       const result = await analytics.V1.Experimental.validateEmail({
-        email: 'test@example.com'
+        email: 'test@example.com',
       });
 
       expect(result).toBe(true);
@@ -28,7 +28,7 @@ describe('BentoExperimental', () => {
         email: 'test@example.com',
         ip: '192.168.1.1',
         name: 'John Doe',
-        userAgent: 'Mozilla/5.0'
+        userAgent: 'Mozilla/5.0',
       });
 
       expect(result).toBe(true);
@@ -38,7 +38,7 @@ describe('BentoExperimental', () => {
       setupMockFetch({ valid: false });
 
       const result = await analytics.V1.Experimental.validateEmail({
-        email: 'invalid@email'
+        email: 'invalid@email',
       });
 
       expect(result).toBe(false);
@@ -49,7 +49,7 @@ describe('BentoExperimental', () => {
 
       await expect(
         analytics.V1.Experimental.validateEmail({
-          email: 'test@example.com'
+          email: 'test@example.com',
         })
       ).rejects.toThrow();
     });
@@ -59,11 +59,11 @@ describe('BentoExperimental', () => {
     test('successfully guesses gender with high confidence', async () => {
       setupMockFetch({
         gender: 'female',
-        confidence: 0.95
+        confidence: 0.95,
       });
 
       const result = await analytics.V1.Experimental.guessGender({
-        name: 'Elizabeth'
+        name: 'Elizabeth',
       });
 
       expect(result.gender).toBe('female');
@@ -73,11 +73,11 @@ describe('BentoExperimental', () => {
     test('handles unknown gender', async () => {
       setupMockFetch({
         gender: null,
-        confidence: null
+        confidence: null,
       });
 
       const result = await analytics.V1.Experimental.guessGender({
-        name: 'Unknown'
+        name: 'Unknown',
       });
 
       expect(result.gender).toBeNull();
@@ -87,11 +87,11 @@ describe('BentoExperimental', () => {
     test('handles low confidence result', async () => {
       setupMockFetch({
         gender: 'male',
-        confidence: 0.3
+        confidence: 0.3,
       });
 
       const result = await analytics.V1.Experimental.guessGender({
-        name: 'Pat'
+        name: 'Pat',
       });
 
       expect(result.gender).toBe('male');
@@ -106,14 +106,14 @@ describe('BentoExperimental', () => {
         query: 'example.com',
         results: {
           'blacklist1.com': false,
-          'blacklist2.com': true
-        }
+          'blacklist2.com': true,
+        },
       };
 
       setupMockFetch(mockResponse);
 
       const result = await analytics.V1.Experimental.getBlacklistStatus({
-        domain: 'example.com'
+        domain: 'example.com',
       });
 
       expect(result.query).toBe('example.com');
@@ -127,14 +127,14 @@ describe('BentoExperimental', () => {
         query: '192.168.1.1',
         results: {
           'blacklist1.com': false,
-          'blacklist2.com': false
-        }
+          'blacklist2.com': false,
+        },
       };
 
       setupMockFetch(mockResponse);
 
       const result = await analytics.V1.Experimental.getBlacklistStatus({
-        ipAddress: '192.168.1.1'
+        ipAddress: '192.168.1.1',
       });
 
       expect(result.query).toBe('192.168.1.1');
@@ -145,13 +145,13 @@ describe('BentoExperimental', () => {
       const mockResponse = {
         description: 'Empty check result',
         query: 'example.com',
-        results: {}
+        results: {},
       };
 
       setupMockFetch(mockResponse);
 
       const result = await analytics.V1.Experimental.getBlacklistStatus({
-        domain: 'example.com'
+        domain: 'example.com',
       });
 
       expect(result.results).toEqual({});
@@ -162,7 +162,7 @@ describe('BentoExperimental', () => {
 
       await expect(
         analytics.V1.Experimental.getBlacklistStatus({
-          domain: 'example.com'
+          domain: 'example.com',
         })
       ).rejects.toThrow();
     });
@@ -179,7 +179,7 @@ describe('BentoExperimental', () => {
           sexual: false,
           'sexual/minors': false,
           violence: false,
-          'violence/graphic': false
+          'violence/graphic': false,
         },
         category_scores: {
           hate: 0.01,
@@ -188,8 +188,8 @@ describe('BentoExperimental', () => {
           sexual: 0.01,
           'sexual/minors': 0.01,
           violence: 0.01,
-          'violence/graphic': 0.01
-        }
+          'violence/graphic': 0.01,
+        },
       };
 
       setupMockFetch(mockResponse);
@@ -213,7 +213,7 @@ describe('BentoExperimental', () => {
           sexual: false,
           'sexual/minors': false,
           violence: false,
-          'violence/graphic': false
+          'violence/graphic': false,
         },
         category_scores: {
           hate: 0.92,
@@ -222,8 +222,8 @@ describe('BentoExperimental', () => {
           sexual: 0.01,
           'sexual/minors': 0.01,
           violence: 0.01,
-          'violence/graphic': 0.01
-        }
+          'violence/graphic': 0.01,
+        },
       };
 
       setupMockFetch(mockResponse);
@@ -246,6 +246,87 @@ describe('BentoExperimental', () => {
     });
   });
 
+  describe('geolocate', () => {
+    test('successfully geolocates IP address', async () => {
+      const mockResponse = {
+        city_name: 'San Francisco',
+        continent_code: 'NA',
+        country_code2: 'US',
+        country_code3: 'USA',
+        country_name: 'United States',
+        ip: '192.168.1.1',
+        latitude: 37.7749,
+        longitude: -122.4194,
+        postal_code: '94105',
+        real_region_name: 'California',
+        region_name: 'CA',
+        request: '192.168.1.1',
+      };
+
+      setupMockFetch(mockResponse);
+
+      const result = await analytics.V1.Experimental.geolocate({
+        ip: '192.168.1.1',
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.city_name).toBe('San Francisco');
+      expect(result?.country_name).toBe('United States');
+    });
+
+    test('returns null for empty response', async () => {
+      setupMockFetch({});
+
+      const result = await analytics.V1.Experimental.geolocate({
+        ip: '192.168.1.1',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(
+        analytics.V1.Experimental.geolocate({
+          ip: '192.168.1.1',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('checkBlacklist', () => {
+    test('successfully checks blacklist status', async () => {
+      const mockResponse = {
+        description: 'Blacklist check',
+        query: 'example.com',
+        results: {
+          'blacklist1.com': false,
+          'blacklist2.com': true,
+        },
+      };
+
+      setupMockFetch(mockResponse);
+
+      const result = await analytics.V1.Experimental.checkBlacklist({
+        ip: 'example.com',
+      });
+
+      expect(result.query).toBe('example.com');
+      expect(result.results['blacklist2.com']).toBe(true);
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(
+        analytics.V1.Experimental.checkBlacklist({
+          ip: '192.168.1.1',
+        })
+      ).rejects.toThrow();
+    });
+  });
+
   describe('geoLocateIP', () => {
     test('successfully geolocates IP address', async () => {
       const mockResponse = {
@@ -260,7 +341,7 @@ describe('BentoExperimental', () => {
         postal_code: '94105',
         real_region_name: 'California',
         region_name: 'CA',
-        request: '192.168.1.1'
+        request: '192.168.1.1',
       };
 
       setupMockFetch(mockResponse);
@@ -276,17 +357,13 @@ describe('BentoExperimental', () => {
     test('handles invalid IP address', async () => {
       setupMockFetch({ error: 'Invalid IP' }, 400);
 
-      await expect(
-        analytics.V1.Experimental.geoLocateIP('invalid-ip')
-      ).rejects.toThrow();
+      await expect(analytics.V1.Experimental.geoLocateIP('invalid-ip')).rejects.toThrow();
     });
 
     test('handles server error gracefully', async () => {
       setupMockFetch({ error: 'Server Error' }, 500);
 
-      await expect(
-        analytics.V1.Experimental.geoLocateIP('192.168.1.1')
-      ).rejects.toThrow();
+      await expect(analytics.V1.Experimental.geoLocateIP('192.168.1.1')).rejects.toThrow();
     });
   });
 });

--- a/__tests__/helpers/mockFetch.test.ts
+++ b/__tests__/helpers/mockFetch.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, describe } from 'bun:test';
+import { getEndpointFromUrl } from './mockFetch';
+
+describe('mockFetch helpers', () => {
+  describe('getEndpointFromUrl', () => {
+    test('extracts endpoint from full URL', () => {
+      const url = 'https://app.bentonow.com/api/v1/fetch/broadcasts';
+      const endpoint = getEndpointFromUrl(url);
+      expect(endpoint).toBe('/fetch/broadcasts');
+    });
+
+    test('extracts endpoint with query parameters', () => {
+      const url = 'https://app.bentonow.com/api/v1/fetch/subscribers?site_uuid=123&email=test@example.com';
+      const endpoint = getEndpointFromUrl(url);
+      expect(endpoint).toBe('/fetch/subscribers');
+    });
+
+    test('handles batch endpoints', () => {
+      const url = 'https://app.bentonow.com/api/v1/batch/events';
+      const endpoint = getEndpointFromUrl(url);
+      expect(endpoint).toBe('/batch/events');
+    });
+
+    test('returns null for empty URL', () => {
+      const endpoint = getEndpointFromUrl('');
+      expect(endpoint).toBeNull();
+    });
+
+    test('returns null for URLs without /api/v1', () => {
+      const url = 'https://example.com/some/path';
+      const endpoint = getEndpointFromUrl(url);
+      expect(endpoint).toBeNull();
+    });
+
+    test('extracts endpoint from experimental endpoint', () => {
+      const url = 'https://app.bentonow.com/api/v1/experimental/validation';
+      const endpoint = getEndpointFromUrl(url);
+      expect(endpoint).toBe('/experimental/validation');
+    });
+  });
+});

--- a/__tests__/helpers/mockFetch.ts
+++ b/__tests__/helpers/mockFetch.ts
@@ -1,8 +1,16 @@
 import { mock } from 'bun:test';
 
+// Store the last URL and method for verification in tests
+export let lastFetchUrl: string | null = null;
+export let lastFetchMethod: string | null = null;
+
 export const setupMockFetch = (response: any, status = 200, contentType = 'application/json') => {
   mock.module('cross-fetch', () => ({
-    default: (_url: string, _options: RequestInit) => {
+    default: (url: string, options: RequestInit) => {
+      // Capture URL and method for test verification
+      lastFetchUrl = url;
+      lastFetchMethod = options?.method || 'GET';
+
       return Promise.resolve({
         status,
         ok: status >= 200 && status < 300,
@@ -14,9 +22,19 @@ export const setupMockFetch = (response: any, status = 200, contentType = 'appli
           return Promise.resolve(JSON.stringify(response));
         },
         headers: new Headers({
-          'Content-Type': contentType
-        })
+          'Content-Type': contentType,
+        }),
       });
-    }
+    },
   }));
+};
+
+/**
+ * Helper function to extract the endpoint from a full URL
+ * e.g., "https://app.bentonow.com/api/v1/fetch/broadcasts" => "/fetch/broadcasts"
+ */
+export const getEndpointFromUrl = (url: string): string | null => {
+  if (!url) return null;
+  const match = url.match(/\/api\/v1(.+?)(\?|$)/);
+  return match ? match[1] : null;
 };

--- a/__tests__/sequences/sequences.test.ts
+++ b/__tests__/sequences/sequences.test.ts
@@ -1,0 +1,122 @@
+import { expect, test, describe, beforeEach } from 'bun:test';
+import { Analytics } from '../../src';
+import { mockOptions } from '../helpers/mockClient';
+import { setupMockFetch, lastFetchUrl, lastFetchMethod } from '../helpers/mockFetch';
+import { EntityType } from '../../src/sdk/enums';
+
+describe('BentoSequences', () => {
+  let analytics: Analytics;
+
+  beforeEach(() => {
+    analytics = new Analytics(mockOptions);
+  });
+
+  describe('getSequences', () => {
+    test('successfully retrieves sequences with email templates', async () => {
+      const mockSequences = {
+        data: [
+          {
+            id: 'seq-1',
+            type: EntityType.SEQUENCES,
+            attributes: {
+              name: 'Onboarding Sequence',
+              created_at: '2024-01-01T00:00:00Z',
+              email_templates: [
+                { id: 1, subject: 'Welcome Email', stats: { opened: 100, clicked: 50 } },
+                { id: 2, subject: 'Getting Started', stats: { opened: 80, clicked: 40 } },
+              ],
+            },
+          },
+          {
+            id: 'seq-2',
+            type: EntityType.SEQUENCES,
+            attributes: {
+              name: 'Re-engagement Sequence',
+              created_at: '2024-02-01T00:00:00Z',
+              email_templates: [{ id: 3, subject: 'We Miss You', stats: null }],
+            },
+          },
+        ],
+      };
+
+      setupMockFetch(mockSequences);
+
+      const result = await analytics.V1.Sequences.getSequences();
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2);
+      expect(result![0].attributes.name).toBe('Onboarding Sequence');
+      expect(result![0].attributes.email_templates).toHaveLength(2);
+      expect(result![1].attributes.name).toBe('Re-engagement Sequence');
+    });
+
+    test('uses correct endpoint for GET request', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Sequences.getSequences();
+
+      expect(lastFetchUrl).toContain('/fetch/sequences');
+      expect(lastFetchMethod).toBe('GET');
+    });
+
+    test('returns null when response is empty object', async () => {
+      setupMockFetch({});
+
+      const result = await analytics.V1.Sequences.getSequences();
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when response has no data', async () => {
+      setupMockFetch({ data: null });
+
+      const result = await analytics.V1.Sequences.getSequences();
+
+      expect(result).toBeNull();
+    });
+
+    test('returns empty array when no sequences exist', async () => {
+      setupMockFetch({ data: [] });
+
+      const result = await analytics.V1.Sequences.getSequences();
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(0);
+    });
+
+    test('handles sequence with empty email templates', async () => {
+      const mockSequences = {
+        data: [
+          {
+            id: 'seq-1',
+            type: EntityType.SEQUENCES,
+            attributes: {
+              name: 'Empty Sequence',
+              created_at: '2024-01-01T00:00:00Z',
+              email_templates: [],
+            },
+          },
+        ],
+      };
+
+      setupMockFetch(mockSequences);
+
+      const result = await analytics.V1.Sequences.getSequences();
+
+      expect(result).not.toBeNull();
+      expect(result![0].attributes.email_templates).toHaveLength(0);
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(analytics.V1.Sequences.getSequences()).rejects.toThrow();
+    });
+
+    test('handles 401 unauthorized error', async () => {
+      setupMockFetch({ error: 'Unauthorized' }, 401);
+
+      await expect(analytics.V1.Sequences.getSequences()).rejects.toThrow();
+    });
+  });
+});

--- a/__tests__/versions/v1/index.test.ts
+++ b/__tests__/versions/v1/index.test.ts
@@ -11,7 +11,8 @@ import {
   BentoExperimental,
   BentoFields,
   BentoForms,
-  BentoSubscribers, BentoTags,
+  BentoSubscribers,
+  BentoTags,
 } from '../../../src/sdk';
 
 // Define interface for custom fields
@@ -77,8 +78,8 @@ describe('BentoAPIV1', () => {
       const customOptions = {
         ...mockOptions,
         clientOptions: {
-          baseUrl: 'https://custom.api.com'
-        }
+          baseUrl: 'https://custom.api.com',
+        },
       };
       const customApi = new BentoAPIV1<CustomFields, CustomEvents>(customOptions);
       const client = (customApi as any)._client;
@@ -95,11 +96,11 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         fields: {
-          customField: 'value'
+          customField: 'value',
         },
         details: {
-          someDetail: 'value'
-        }
+          someDetail: 'value',
+        },
       });
     });
   });
@@ -116,9 +117,9 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: [],
-            unsubscribed_at: null
-          }
-        }
+            unsubscribed_at: null,
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
@@ -136,9 +137,9 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: [],
-            unsubscribed_at: new Date().toISOString()
-          }
-        }
+            unsubscribed_at: new Date().toISOString(),
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
@@ -156,15 +157,15 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: ['tag-1'],
-            unsubscribed_at: null
-          }
-        }
+            unsubscribed_at: null,
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
       const result = await api.Commands.addTag({
         email: 'test@example.com',
-        tagName: 'TestTag'
+        tagName: 'TestTag',
       });
       expect(result?.attributes.cached_tag_ids).toContain('tag-1');
     });
@@ -179,15 +180,15 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: [],
-            unsubscribed_at: null
-          }
-        }
+            unsubscribed_at: null,
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
       const result = await api.Commands.removeTag({
         email: 'test@example.com',
-        tagName: 'TestTag'
+        tagName: 'TestTag',
       });
       expect(result?.attributes.cached_tag_ids).toHaveLength(0);
     });
@@ -205,10 +206,10 @@ describe('BentoAPIV1', () => {
               key: 'testField',
               name: 'Test Field',
               created_at: new Date().toISOString(),
-              whitelisted: true
-            }
-          }
-        ]
+              whitelisted: true,
+            },
+          },
+        ],
       };
       setupMockFetch(mockResponse);
 
@@ -230,8 +231,8 @@ describe('BentoAPIV1', () => {
       const customOptions = {
         ...mockOptions,
         clientOptions: {
-          baseUrl: 'https://custom.api.com'
-        }
+          baseUrl: 'https://custom.api.com',
+        },
       };
       const customApi = new BentoAPIV1<CustomFields, CustomEvents>(customOptions);
       const client = (customApi as any)._client;
@@ -249,11 +250,11 @@ describe('BentoAPIV1', () => {
         email: 'test@example.com',
         fields: {
           firstName: 'John',
-          lastName: 'Doe'
+          lastName: 'Doe',
         },
         details: {
-          someDetail: 'value'
-        }
+          someDetail: 'value',
+        },
       });
     });
 
@@ -261,13 +262,15 @@ describe('BentoAPIV1', () => {
       setupMockFetch({ results: 1 });
 
       const result = await api.Batch.importEvents({
-        events: [{
-          type: '$custom',
-          email: 'test@example.com',
-          details: {
-            firstName: 'John'
-          }
-        }]
+        events: [
+          {
+            type: '$custom',
+            email: 'test@example.com',
+            details: {
+              firstName: 'John',
+            },
+          },
+        ],
       });
 
       expect(result).toBe(1);
@@ -280,13 +283,13 @@ describe('BentoAPIV1', () => {
         type: '$pageview',
         email: 'test@example.com',
         fields: {
-          firstName: 'John'
+          firstName: 'John',
         },
         details: {
           url: 'https://example.com',
           title: 'Test Page',
-          referrer: 'https://google.com'
-        }
+          referrer: 'https://google.com',
+        },
       });
     });
 
@@ -297,13 +300,13 @@ describe('BentoAPIV1', () => {
         type: '$browser',
         email: 'test@example.com',
         fields: {
-          firstName: 'John'
+          firstName: 'John',
         },
         details: {
           userAgent: 'Mozilla/5.0',
           language: 'en-US',
-          platform: 'MacOS'
-        }
+          platform: 'MacOS',
+        },
       });
     });
 
@@ -315,12 +318,12 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         fields: {
-          firstName: 'John'
+          firstName: 'John',
         },
         details: {
-          someDetail: 'value'
+          someDetail: 'value',
         },
-        date: eventDate
+        date: eventDate,
       });
     });
   });
@@ -337,9 +340,9 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: [],
-            unsubscribed_at: null
-          }
-        }
+            unsubscribed_at: null,
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
@@ -357,9 +360,9 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: [],
-            unsubscribed_at: new Date().toISOString()
-          }
-        }
+            unsubscribed_at: new Date().toISOString(),
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
@@ -377,15 +380,15 @@ describe('BentoAPIV1', () => {
             email: 'test@example.com',
             fields: null,
             cached_tag_ids: ['tag-1'],
-            unsubscribed_at: null
-          }
-        }
+            unsubscribed_at: null,
+          },
+        },
       };
       setupMockFetch(mockResponse);
 
       const result = await api.Commands.addTag({
         email: 'test@example.com',
-        tagName: 'TestTag'
+        tagName: 'TestTag',
       });
       expect(result?.attributes.cached_tag_ids).toContain('tag-1');
     });
@@ -403,10 +406,10 @@ describe('BentoAPIV1', () => {
               key: 'testField',
               name: 'Test Field',
               created_at: new Date().toISOString(),
-              whitelisted: true
-            }
-          }
-        ]
+              whitelisted: true,
+            },
+          },
+        ],
       };
       setupMockFetch(mockResponse);
 
@@ -415,7 +418,6 @@ describe('BentoAPIV1', () => {
       expect(result?.[0]?.attributes.key).toBe('testField');
     });
   });
-
 
   describe('track method variations', () => {
     test('tracks event with all possible fields', async () => {
@@ -428,14 +430,14 @@ describe('BentoAPIV1', () => {
         fields: {
           firstName: 'John',
           lastName: 'Doe',
-          customField: 'value'
+          customField: 'value',
         },
         details: {
           detailField: 'value',
           nestedDetail: {
-            key: 'value'
-          }
-        }
+            key: 'value',
+          },
+        },
       });
     });
 
@@ -445,7 +447,7 @@ describe('BentoAPIV1', () => {
       await api.track({
         type: '$custom',
         email: 'test@example.com',
-        fields: {}
+        fields: {},
       });
     });
 
@@ -456,7 +458,7 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         date: new Date('invalid date'), // Should trigger date validation
-        fields: {}
+        fields: {},
       });
     });
 
@@ -467,7 +469,7 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         date: new Date('2025-12-31'),
-        fields: {}
+        fields: {},
       });
     });
 
@@ -478,7 +480,7 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         date: new Date('1970-01-01'),
-        fields: {}
+        fields: {},
       });
     });
   });
@@ -489,29 +491,33 @@ describe('BentoAPIV1', () => {
       setupMockFetch({ results: 1 });
 
       await api.Batch.importEvents({
-        events: [{
-          type: BentoEvents.PURCHASE,
-          email: 'test@example.com',
-          date: new Date(),
-          details: {
-            unique: {
-              key: 'order_123'
+        events: [
+          {
+            type: BentoEvents.PURCHASE,
+            email: 'test@example.com',
+            date: new Date(),
+            details: {
+              unique: {
+                key: 'order_123',
+              },
+              value: {
+                currency: 'USD',
+                amount: 99.99,
+              },
+              cart: {
+                abandoned_checkout_url: 'https://example.com/cart',
+                items: [
+                  {
+                    product_id: 'prod_123',
+                    product_name: 'Test Product',
+                    product_sku: 'SKU123',
+                    custom_field: 'custom value', // Added to show string indexer
+                  },
+                ],
+              },
             },
-            value: {
-              currency: 'USD',
-              amount: 99.99
-            },
-            cart: {
-              abandoned_checkout_url: 'https://example.com/cart',
-              items: [{
-                product_id: 'prod_123',
-                product_name: 'Test Product',
-                product_sku: 'SKU123',
-                custom_field: 'custom value'  // Added to show string indexer
-              }]
-            }
-          }
-        }]
+          },
+        ],
       });
     });
 
@@ -519,19 +525,21 @@ describe('BentoAPIV1', () => {
       setupMockFetch({ results: 1 });
 
       await api.Batch.importEvents({
-        events: [{
-          type: BentoEvents.PURCHASE,
-          email: 'test@example.com',
-          details: {
-            unique: {
-              key: 'order_123'
+        events: [
+          {
+            type: BentoEvents.PURCHASE,
+            email: 'test@example.com',
+            details: {
+              unique: {
+                key: 'order_123',
+              },
+              value: {
+                currency: 'USD',
+                amount: 99.99,
+              },
             },
-            value: {
-              currency: 'USD',
-              amount: 99.99
-            }
-          }
-        }]
+          },
+        ],
       });
     });
   });
@@ -545,7 +553,7 @@ describe('BentoAPIV1', () => {
         type: '$custom',
         email: 'test@example.com',
         fields: {},
-        details: {}
+        details: {},
       });
     });
 
@@ -560,11 +568,11 @@ describe('BentoAPIV1', () => {
           level1: {
             level2: {
               level3: {
-                value: 'deeply nested'
-              }
-            }
-          }
-        }
+                value: 'deeply nested',
+              },
+            },
+          },
+        },
       });
     });
 
@@ -577,8 +585,8 @@ describe('BentoAPIV1', () => {
         fields: {},
         details: {
           arrayField: ['value1', 'value2', 'value3'],
-          mixedArray: [1, 'string', { key: 'value' }]
-        }
+          mixedArray: [1, 'string', { key: 'value' }],
+        },
       });
     });
   });
@@ -594,24 +602,24 @@ describe('BentoAPIV1', () => {
             type: '$custom',
             email: 'test1@example.com',
             details: {
-              customField: 'value1'
-            }
+              customField: 'value1',
+            },
           },
           {
             type: '$pageview',
             email: 'test2@example.com',
             details: {
-              url: 'https://example.com'
-            }
+              url: 'https://example.com',
+            },
           },
           {
             type: '$browser',
             email: 'test3@example.com',
             details: {
-              userAgent: 'Mozilla/5.0'
-            }
-          }
-        ]
+              userAgent: 'Mozilla/5.0',
+            },
+          },
+        ],
       });
     });
 
@@ -624,22 +632,95 @@ describe('BentoAPIV1', () => {
             type: '$custom',
             email: 'test1@example.com',
             date: new Date(),
-            details: {}
+            details: {},
           },
           {
             type: '$custom',
             email: 'test2@example.com',
             date: new Date('2024-01-08T12:00:00Z'),
-            details: {}
+            details: {},
           },
           {
             type: '$custom',
             email: 'test3@example.com',
             date: new Date('2024-01-08'),
-            details: {}
-          }
-        ]
+            details: {},
+          },
+        ],
       });
+    });
+  });
+
+  // API V1 Helper Methods Testing
+  describe('helper methods', () => {
+    test('successfully tags subscriber through tagSubscriber method', async () => {
+      setupMockFetch({ results: 1 });
+
+      const result = await api.tagSubscriber({
+        email: 'test@example.com',
+        tagName: 'premium',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('successfully removes subscriber through removeSubscriber method', async () => {
+      setupMockFetch({ results: 1 });
+
+      const result = await api.removeSubscriber({
+        email: 'test@example.com',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('successfully adds subscriber through addSubscriber method', async () => {
+      setupMockFetch({ results: 1 });
+
+      const result = await api.addSubscriber({
+        email: 'new@example.com',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('successfully updates fields through updateFields method', async () => {
+      setupMockFetch({ results: 1 });
+
+      const result = await api.updateFields({
+        email: 'test@example.com',
+        fields: {
+          firstName: 'Updated',
+          lastName: 'Name',
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('successfully tracks purchase through trackPurchase method', async () => {
+      setupMockFetch({ results: 1 });
+
+      const result = await api.trackPurchase({
+        email: 'test@example.com',
+        purchaseDetails: {
+          unique: { key: 'order-123' },
+          value: { currency: 'USD', amount: 9999 },
+        },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false when helper method fails', async () => {
+      setupMockFetch({ results: 0 });
+
+      const result = await api.tagSubscriber({
+        email: 'test@example.com',
+        tagName: 'premium',
+      });
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/__tests__/versions/v1/upsert.test.ts
+++ b/__tests__/versions/v1/upsert.test.ts
@@ -2,7 +2,6 @@ import { expect, test, describe, beforeEach } from 'bun:test';
 import { Analytics } from '../../../src';
 import { mockOptions } from '../../helpers/mockClient';
 import { setupMockFetch } from '../../helpers/mockFetch';
-import { EntityType } from '../../../src/sdk/enums';
 
 describe('BentoAPIV1 - upsertSubscriber', () => {
   let analytics: Analytics;
@@ -11,30 +10,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
     analytics = new Analytics(mockOptions);
   });
 
-  test('successfully creates new subscriber', async () => {
-    // Mock the import response
+  test('successfully queues subscriber for import', async () => {
     setupMockFetch({ results: 1 });
-
-    // Mock the get subscriber response for a new subscriber
-    const mockSubscriber = {
-      data: {
-        id: 'new-sub-1',
-        type: EntityType.VISITORS,
-        attributes: {
-          uuid: 'uuid-123',
-          email: 'new@example.com',
-          fields: {
-            firstName: 'John',
-            lastName: 'Doe',
-          },
-          cached_tag_ids: [],
-          unsubscribed_at: null,
-        },
-      },
-    };
-
-    // Setup the second fetch call to return the subscriber
-    setupMockFetch(mockSubscriber);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'new@example.com',
@@ -44,36 +21,12 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       },
     });
 
-    expect(result).toBeDefined();
-    expect(result?.attributes.email).toBe('new@example.com');
-    expect(result?.attributes.fields?.firstName).toBe('John');
+    // Now returns the number of subscribers queued (1)
+    expect(result).toBe(1);
   });
 
-  test('successfully updates existing subscriber', async () => {
-    // Mock the import response
+  test('successfully queues existing subscriber for update', async () => {
     setupMockFetch({ results: 1 });
-
-    // Mock the get subscriber response for an existing subscriber
-    const mockSubscriber = {
-      data: {
-        id: 'existing-sub-1',
-        type: EntityType.VISITORS,
-        attributes: {
-          uuid: 'uuid-456',
-          email: 'existing@example.com',
-          fields: {
-            firstName: 'Jane',
-            lastName: 'Smith',
-            company: 'Updated Corp',
-          },
-          cached_tag_ids: ['existing-tag'],
-          unsubscribed_at: null,
-        },
-      },
-    };
-
-    // Setup the second fetch call to return the updated subscriber
-    setupMockFetch(mockSubscriber);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'existing@example.com',
@@ -84,9 +37,7 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       },
     });
 
-    expect(result).toBeDefined();
-    expect(result?.attributes.email).toBe('existing@example.com');
-    expect(result?.attributes.fields?.company).toBe('Updated Corp');
+    expect(result).toBe(1);
   });
 
   test('handles error during import', async () => {
@@ -102,60 +53,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
     ).rejects.toThrow();
   });
 
-  test('handles error during subscriber fetch', async () => {
-    // First call succeeds (import)
+  test('successfully queues subscriber with tags', async () => {
     setupMockFetch({ results: 1 });
-
-    // Second call fails (get subscriber)
-    setupMockFetch({ error: 'Fetch failed' }, 500);
-
-    await expect(
-      analytics.V1.upsertSubscriber({
-        email: 'test@example.com',
-        fields: {
-          firstName: 'Test',
-        },
-      })
-    ).rejects.toThrow();
-  });
-
-  test('handles subscriber not found after import', async () => {
-    // First call succeeds (import)
-    setupMockFetch({ results: 1 });
-
-    // Second call returns null subscriber
-    setupMockFetch({ data: null });
-
-    const result = await analytics.V1.upsertSubscriber({
-      email: 'test@example.com',
-      fields: {
-        firstName: 'Test',
-      },
-    });
-
-    expect(result).toBeNull();
-  });
-
-  test('successfully upserts with tags', async () => {
-    setupMockFetch({ results: 1 });
-
-    const mockSubscriber = {
-      data: {
-        id: 'sub-tagged',
-        type: EntityType.VISITORS,
-        attributes: {
-          uuid: 'uuid-tagged',
-          email: 'tagged@example.com',
-          fields: {
-            firstName: 'Tagged',
-          },
-          cached_tag_ids: ['tag-1', 'tag-2'],
-          unsubscribed_at: null,
-        },
-      },
-    };
-
-    setupMockFetch(mockSubscriber);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'tagged@example.com',
@@ -165,30 +64,11 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       tags: 'tag-1,tag-2',
     });
 
-    expect(result?.attributes.cached_tag_ids).toContain('tag-1');
-    expect(result?.attributes.cached_tag_ids).toContain('tag-2');
+    expect(result).toBe(1);
   });
 
-  test('successfully upserts with remove_tags', async () => {
+  test('successfully queues subscriber with remove_tags', async () => {
     setupMockFetch({ results: 1 });
-
-    const mockSubscriber = {
-      data: {
-        id: 'sub-removed-tags',
-        type: EntityType.VISITORS,
-        attributes: {
-          uuid: 'uuid-removed',
-          email: 'removed-tags@example.com',
-          fields: {
-            firstName: 'Removed',
-          },
-          cached_tag_ids: [],
-          unsubscribed_at: null,
-        },
-      },
-    };
-
-    setupMockFetch(mockSubscriber);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'removed-tags@example.com',
@@ -198,29 +78,11 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       remove_tags: 'old-tag',
     });
 
-    expect(result?.attributes.cached_tag_ids).toHaveLength(0);
+    expect(result).toBe(1);
   });
 
-  test('successfully upserts with both tags and remove_tags', async () => {
+  test('successfully queues subscriber with both tags and remove_tags', async () => {
     setupMockFetch({ results: 1 });
-
-    const mockSubscriber = {
-      data: {
-        id: 'sub-both-tags',
-        type: EntityType.VISITORS,
-        attributes: {
-          uuid: 'uuid-both',
-          email: 'both-tags@example.com',
-          fields: {
-            firstName: 'Both',
-          },
-          cached_tag_ids: ['new-tag'],
-          unsubscribed_at: null,
-        },
-      },
-    };
-
-    setupMockFetch(mockSubscriber);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'both-tags@example.com',
@@ -231,6 +93,28 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       remove_tags: 'old-tag',
     });
 
-    expect(result?.attributes.cached_tag_ids).toContain('new-tag');
+    expect(result).toBe(1);
+  });
+
+  test('successfully queues subscriber with empty fields', async () => {
+    setupMockFetch({ results: 1 });
+
+    const result = await analytics.V1.upsertSubscriber({
+      email: 'minimal@example.com',
+      fields: {},
+    });
+
+    expect(result).toBe(1);
+  });
+
+  test('returns 0 when no subscribers are queued', async () => {
+    setupMockFetch({ results: 0 });
+
+    const result = await analytics.V1.upsertSubscriber({
+      email: 'test@example.com',
+      fields: {},
+    });
+
+    expect(result).toBe(0);
   });
 });

--- a/__tests__/versions/v1/upsert.test.ts
+++ b/__tests__/versions/v1/upsert.test.ts
@@ -25,12 +25,12 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
           email: 'new@example.com',
           fields: {
             firstName: 'John',
-            lastName: 'Doe'
+            lastName: 'Doe',
           },
           cached_tag_ids: [],
-          unsubscribed_at: null
-        }
-      }
+          unsubscribed_at: null,
+        },
+      },
     };
 
     // Setup the second fetch call to return the subscriber
@@ -40,8 +40,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       email: 'new@example.com',
       fields: {
         firstName: 'John',
-        lastName: 'Doe'
-      }
+        lastName: 'Doe',
+      },
     });
 
     expect(result).toBeDefined();
@@ -64,12 +64,12 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
           fields: {
             firstName: 'Jane',
             lastName: 'Smith',
-            company: 'Updated Corp'
+            company: 'Updated Corp',
           },
           cached_tag_ids: ['existing-tag'],
-          unsubscribed_at: null
-        }
-      }
+          unsubscribed_at: null,
+        },
+      },
     };
 
     // Setup the second fetch call to return the updated subscriber
@@ -80,8 +80,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       fields: {
         firstName: 'Jane',
         lastName: 'Smith',
-        company: 'Updated Corp'
-      }
+        company: 'Updated Corp',
+      },
     });
 
     expect(result).toBeDefined();
@@ -96,8 +96,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       analytics.V1.upsertSubscriber({
         email: 'test@example.com',
         fields: {
-          firstName: 'Test'
-        }
+          firstName: 'Test',
+        },
       })
     ).rejects.toThrow();
   });
@@ -113,8 +113,8 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       analytics.V1.upsertSubscriber({
         email: 'test@example.com',
         fields: {
-          firstName: 'Test'
-        }
+          firstName: 'Test',
+        },
       })
     ).rejects.toThrow();
   });
@@ -129,10 +129,108 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
     const result = await analytics.V1.upsertSubscriber({
       email: 'test@example.com',
       fields: {
-        firstName: 'Test'
-      }
+        firstName: 'Test',
+      },
     });
 
     expect(result).toBeNull();
+  });
+
+  test('successfully upserts with tags', async () => {
+    setupMockFetch({ results: 1 });
+
+    const mockSubscriber = {
+      data: {
+        id: 'sub-tagged',
+        type: EntityType.VISITORS,
+        attributes: {
+          uuid: 'uuid-tagged',
+          email: 'tagged@example.com',
+          fields: {
+            firstName: 'Tagged',
+          },
+          cached_tag_ids: ['tag-1', 'tag-2'],
+          unsubscribed_at: null,
+        },
+      },
+    };
+
+    setupMockFetch(mockSubscriber);
+
+    const result = await analytics.V1.upsertSubscriber({
+      email: 'tagged@example.com',
+      fields: {
+        firstName: 'Tagged',
+      },
+      tags: 'tag-1,tag-2',
+    });
+
+    expect(result?.attributes.cached_tag_ids).toContain('tag-1');
+    expect(result?.attributes.cached_tag_ids).toContain('tag-2');
+  });
+
+  test('successfully upserts with remove_tags', async () => {
+    setupMockFetch({ results: 1 });
+
+    const mockSubscriber = {
+      data: {
+        id: 'sub-removed-tags',
+        type: EntityType.VISITORS,
+        attributes: {
+          uuid: 'uuid-removed',
+          email: 'removed-tags@example.com',
+          fields: {
+            firstName: 'Removed',
+          },
+          cached_tag_ids: [],
+          unsubscribed_at: null,
+        },
+      },
+    };
+
+    setupMockFetch(mockSubscriber);
+
+    const result = await analytics.V1.upsertSubscriber({
+      email: 'removed-tags@example.com',
+      fields: {
+        firstName: 'Removed',
+      },
+      remove_tags: 'old-tag',
+    });
+
+    expect(result?.attributes.cached_tag_ids).toHaveLength(0);
+  });
+
+  test('successfully upserts with both tags and remove_tags', async () => {
+    setupMockFetch({ results: 1 });
+
+    const mockSubscriber = {
+      data: {
+        id: 'sub-both-tags',
+        type: EntityType.VISITORS,
+        attributes: {
+          uuid: 'uuid-both',
+          email: 'both-tags@example.com',
+          fields: {
+            firstName: 'Both',
+          },
+          cached_tag_ids: ['new-tag'],
+          unsubscribed_at: null,
+        },
+      },
+    };
+
+    setupMockFetch(mockSubscriber);
+
+    const result = await analytics.V1.upsertSubscriber({
+      email: 'both-tags@example.com',
+      fields: {
+        firstName: 'Both',
+      },
+      tags: 'new-tag',
+      remove_tags: 'old-tag',
+    });
+
+    expect(result?.attributes.cached_tag_ids).toContain('new-tag');
   });
 });

--- a/__tests__/workflows/workflows.test.ts
+++ b/__tests__/workflows/workflows.test.ts
@@ -1,0 +1,128 @@
+import { expect, test, describe, beforeEach } from 'bun:test';
+import { Analytics } from '../../src';
+import { mockOptions } from '../helpers/mockClient';
+import { setupMockFetch, lastFetchUrl, lastFetchMethod } from '../helpers/mockFetch';
+import { EntityType } from '../../src/sdk/enums';
+
+describe('BentoWorkflows', () => {
+  let analytics: Analytics;
+
+  beforeEach(() => {
+    analytics = new Analytics(mockOptions);
+  });
+
+  describe('getWorkflows', () => {
+    test('successfully retrieves workflows with email templates', async () => {
+      const mockWorkflows = {
+        data: [
+          {
+            id: 'wf-1',
+            type: EntityType.WORKFLOWS,
+            attributes: {
+              name: 'Welcome Workflow',
+              created_at: '2024-01-01T00:00:00Z',
+              email_templates: [
+                { id: 1, subject: 'Welcome!', stats: { opened: 150, clicked: 75 } },
+                { id: 2, subject: 'Next Steps', stats: { opened: 120, clicked: 60 } },
+              ],
+            },
+          },
+          {
+            id: 'wf-2',
+            type: EntityType.WORKFLOWS,
+            attributes: {
+              name: 'Abandoned Cart Workflow',
+              created_at: '2024-02-01T00:00:00Z',
+              email_templates: [{ id: 3, subject: 'You left something behind', stats: null }],
+            },
+          },
+        ],
+      };
+
+      setupMockFetch(mockWorkflows);
+
+      const result = await analytics.V1.Workflows.getWorkflows();
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(2);
+      expect(result![0].attributes.name).toBe('Welcome Workflow');
+      expect(result![0].attributes.email_templates).toHaveLength(2);
+      expect(result![1].attributes.name).toBe('Abandoned Cart Workflow');
+    });
+
+    test('uses correct endpoint for GET request', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Workflows.getWorkflows();
+
+      expect(lastFetchUrl).toContain('/fetch/workflows');
+      expect(lastFetchMethod).toBe('GET');
+    });
+
+    test('returns null when response is empty object', async () => {
+      setupMockFetch({});
+
+      const result = await analytics.V1.Workflows.getWorkflows();
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when response has no data', async () => {
+      setupMockFetch({ data: null });
+
+      const result = await analytics.V1.Workflows.getWorkflows();
+
+      expect(result).toBeNull();
+    });
+
+    test('returns empty array when no workflows exist', async () => {
+      setupMockFetch({ data: [] });
+
+      const result = await analytics.V1.Workflows.getWorkflows();
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveLength(0);
+    });
+
+    test('handles workflow with empty email templates', async () => {
+      const mockWorkflows = {
+        data: [
+          {
+            id: 'wf-1',
+            type: EntityType.WORKFLOWS,
+            attributes: {
+              name: 'Empty Workflow',
+              created_at: '2024-01-01T00:00:00Z',
+              email_templates: [],
+            },
+          },
+        ],
+      };
+
+      setupMockFetch(mockWorkflows);
+
+      const result = await analytics.V1.Workflows.getWorkflows();
+
+      expect(result).not.toBeNull();
+      expect(result![0].attributes.email_templates).toHaveLength(0);
+    });
+
+    test('handles server error gracefully', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500);
+
+      await expect(analytics.V1.Workflows.getWorkflows()).rejects.toThrow();
+    });
+
+    test('handles 401 unauthorized error', async () => {
+      setupMockFetch({ error: 'Unauthorized' }, 401);
+
+      await expect(analytics.V1.Workflows.getWorkflows()).rejects.toThrow();
+    });
+
+    test('handles 429 rate limited error', async () => {
+      setupMockFetch({ error: 'Rate Limited' }, 429);
+
+      await expect(analytics.V1.Workflows.getWorkflows()).rejects.toThrow();
+    });
+  });
+});

--- a/src/sdk/broadcasts/index.ts
+++ b/src/sdk/broadcasts/index.ts
@@ -3,8 +3,9 @@ import type { DataResponse } from '../client/types';
 import type { Broadcast, CreateBroadcastInput, EmailData } from './types';
 
 export class BentoBroadcasts {
-  private readonly _url = '/broadcasts';
-  private readonly _emailsUrl = '/emails';
+  private readonly _fetchUrl = '/fetch/broadcasts';
+  private readonly _batchUrl = '/batch/broadcasts';
+  private readonly _emailsUrl = '/batch/emails';
 
   constructor(private readonly _client: BentoClient) {}
 
@@ -15,7 +16,7 @@ export class BentoBroadcasts {
    */
   public async createEmails(emails: EmailData[]): Promise<number> {
     const result = await this._client.post<{ results: number }>(this._emailsUrl, {
-      emails
+      emails,
     });
     return result.results;
   }
@@ -25,7 +26,7 @@ export class BentoBroadcasts {
    * @returns Promise<Broadcast[]>
    */
   public async getBroadcasts(): Promise<Broadcast[]> {
-    const result = await this._client.get<DataResponse<Broadcast[]>>(this._url);
+    const result = await this._client.get<DataResponse<Broadcast[]>>(this._fetchUrl);
     return result.data ?? [];
   }
 
@@ -35,8 +36,8 @@ export class BentoBroadcasts {
    * @returns Promise<Broadcast[]>
    */
   public async createBroadcast(broadcasts: CreateBroadcastInput[]): Promise<Broadcast[]> {
-    const result = await this._client.post<DataResponse<Broadcast[]>>(this._url, {
-      broadcasts
+    const result = await this._client.post<DataResponse<Broadcast[]>>(this._batchUrl, {
+      broadcasts,
     });
     return result.data ?? [];
   }

--- a/src/sdk/broadcasts/types.ts
+++ b/src/sdk/broadcasts/types.ts
@@ -24,6 +24,10 @@ export type Broadcast = BaseEntity<BroadcastAttributes>;
 
 export type CreateBroadcastInput = Omit<BroadcastAttributes, 'created_at'>;
 
+/**
+ * Email data for transactional emails.
+ * Note: This is the same structure as TransactionalEmail in batch/types.ts
+ */
 export type EmailData = {
   to: string;
   from: string;

--- a/src/sdk/client/errors.ts
+++ b/src/sdk/client/errors.ts
@@ -18,3 +18,10 @@ export class AuthorNotAuthorizedError extends Error {
     this.name = 'AuthorNotAuthorizedError';
   }
 }
+
+export class RequestTimeoutError extends Error {
+  constructor(message = 'Request timed out') {
+    super(message);
+    this.name = 'RequestTimeoutError';
+  }
+}

--- a/src/sdk/client/index.ts
+++ b/src/sdk/client/index.ts
@@ -182,7 +182,7 @@ export class BentoClient {
 
     const queryParameters = new URLSearchParams();
     for (const [key, value] of Object.entries(body)) {
-      queryParameters.append(key, value);
+      queryParameters.append(key, String(value));
     }
 
     return queryParameters.toString();

--- a/src/sdk/interfaces.ts
+++ b/src/sdk/interfaces.ts
@@ -12,4 +12,8 @@ export interface AuthenticationOptions {
 
 export interface ClientOptions {
   baseUrl?: string;
+  /**
+   * Request timeout in milliseconds. Defaults to 30000 (30 seconds).
+   */
+  timeout?: number;
 }


### PR DESCRIPTION
## Changes Overview

- Fixed API endpoint handling for broadcasts with separate fetch and batch URLs
- Added comprehensive test coverage for various SDK modules (workflows, sequences, email templates, upsert)
- Implemented request timeout mechanism with configurable duration
- Improved error handling for network requests and JSON parsing
- Enhanced query parameter handling by converting non-string values to strings
- Updated subscriber upsert method to return import queue count
- Added client timeout configuration option

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **SDK client updates**
> 
> - Adds configurable request timeout via `clientOptions.timeout` (default 30s) with AbortController; introduces `RequestTimeoutError`
> - Hardens response handling: typed content-type parsing, clearer JSON parse failures, specific 401/429/author errors, and ensures query params are stringified
> 
> **Broadcasts API**
> 
> - Uses `GET /fetch/broadcasts` and `POST /batch/broadcasts`; transactional emails via `POST /batch/emails`
> 
> **Subscriber upsert**
> 
> - `V1.upsertSubscriber` now enqueues via batch import and returns the number queued (not the subscriber object)
> 
> **Docs & tests**
> 
> - README documents timeout config and error types; clarifies `upsertSubscriber` behavior
> - Extensive tests added/updated for broadcasts, client timeout/errors, sequences, workflows, email templates, experimental helpers, and test utilities (URL/method capture)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c330f961a9b1029965a839e605edd968b6bea64a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->