### PR TITLE
Z-007

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,11 @@ bento.V1.removeSubscriber({
 
 #### upsertSubscriber
 
-Queues a subscriber for import - creates a new subscriber or updates an existing one. Returns the number of subscribers queued (1 if successful).
-
-> **Note:** This uses the batch import API which processes asynchronously. The import may take 1-5 minutes to complete. If you need to fetch the subscriber after creation, wait an appropriate amount of time and call `Subscribers.getSubscribers()` separately.
+Creates or updates a subscriber. The SDK queues the import job and then attempts to fetch
+the subscriber record once the job has been accepted.
 
 ```javascript
-const queued = await analytics.V1.upsertSubscriber({
+const subscriber = await analytics.V1.upsertSubscriber({
   email: 'user@example.com',
   fields: {
     firstName: 'John',
@@ -198,8 +197,10 @@ const queued = await analytics.V1.upsertSubscriber({
   tags: 'lead,mql',
   remove_tags: 'customer',
 });
-// queued === 1 means the subscriber was queued for import
 ```
+
+> **Note:** Imports are processed asynchronously by Bento and may take 1-5 minutes to
+> complete. If the subscriber is not yet available, the method will return `null`.
 
 #### updateFields
 

--- a/__tests__/batch/events.test.ts
+++ b/__tests__/batch/events.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe, beforeEach } from 'bun:test';
 import { Analytics } from '../../src';
 import { mockOptions } from '../helpers/mockClient';
-import { setupMockFetch } from '../helpers/mockFetch';
+import { setupMockFetch, lastFetchSignal } from '../helpers/mockFetch';
 import { BentoEvents } from '../../src/sdk/batch/enums';
 describe('BentoBatch - importEvents', () => {
   let analytics: Analytics;
@@ -309,5 +309,21 @@ describe('BentoBatch - importEvents', () => {
     });
 
     expect(result).toBe(3);
+  });
+
+  test('uses unlimited timeout for imports', async () => {
+    setupMockFetch({ results: 1 });
+
+    await analytics.V1.Batch.importEvents({
+      events: [{
+        type: BentoEvents.TAG,
+        email: 'signal@example.com',
+        details: {
+          tag: 'VIP'
+        }
+      }]
+    });
+
+    expect(lastFetchSignal).toBeNull();
   });
 });

--- a/__tests__/batch/subscribers.test.ts
+++ b/__tests__/batch/subscribers.test.ts
@@ -1,0 +1,28 @@
+import { expect, test, describe, beforeEach } from 'bun:test';
+import { Analytics } from '../../src';
+import { mockOptions } from '../helpers/mockClient';
+import { setupMockFetch, lastFetchSignal } from '../helpers/mockFetch';
+
+describe('BentoBatch - importSubscribers', () => {
+  let analytics: Analytics;
+
+  beforeEach(() => {
+    analytics = new Analytics(mockOptions);
+  });
+
+  test('successfully imports subscribers without timeout signal', async () => {
+    setupMockFetch({ results: 1 });
+
+    const result = await analytics.V1.Batch.importSubscribers({
+      subscribers: [
+        {
+          email: 'test@example.com',
+          firstName: 'Test',
+        },
+      ],
+    });
+
+    expect(result).toBe(1);
+    expect(lastFetchSignal).toBeNull();
+  });
+});

--- a/__tests__/client/client.test.ts
+++ b/__tests__/client/client.test.ts
@@ -1,7 +1,7 @@
 import { expect, test, describe, beforeEach, mock } from 'bun:test';
 import { Analytics } from '../../src';
 import { mockOptions } from '../helpers/mockClient';
-import { setupMockFetch } from '../helpers/mockFetch';
+import { setupMockFetch, lastFetchSignal } from '../helpers/mockFetch';
 import { NotAuthorizedError, RateLimitedError, RequestTimeoutError } from '../../src';
 
 describe('BentoClient', () => {
@@ -227,6 +227,14 @@ describe('BentoClient', () => {
     test('uses default timeout of 30000ms', () => {
       const client = (analytics.V1 as any)._client;
       expect(client._timeout).toBe(30000);
+    });
+
+    test('attaches AbortSignal to standard requests', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Fields.getFields();
+
+      expect(lastFetchSignal).not.toBeNull();
     });
   });
 

--- a/__tests__/helpers/mockFetch.test.ts
+++ b/__tests__/helpers/mockFetch.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'bun:test';
-import { getEndpointFromUrl } from './mockFetch';
+import { getEndpointFromUrl, setupMockFetch } from './mockFetch';
 
 describe('mockFetch helpers', () => {
   describe('getEndpointFromUrl', () => {
@@ -36,6 +36,49 @@ describe('mockFetch helpers', () => {
       const url = 'https://app.bentonow.com/api/v1/experimental/validation';
       const endpoint = getEndpointFromUrl(url);
       expect(endpoint).toBe('/experimental/validation');
+    });
+  });
+
+  describe('setupMockFetch text handling', () => {
+    test('returns raw string for text/plain body', async () => {
+      setupMockFetch('plain text', 200, 'text/plain');
+      const fetchModule = await import('cross-fetch');
+      const response = await fetchModule.default('https://app.bentonow.com/api/v1/test');
+      const text = await response.text();
+      expect(text).toBe('plain text');
+    });
+
+    test('returns error field when provided', async () => {
+      setupMockFetch({ error: 'Server Error' }, 500, 'text/plain');
+      const fetchModule = await import('cross-fetch');
+      const response = await fetchModule.default('https://app.bentonow.com/api/v1/test');
+      const text = await response.text();
+      expect(text).toBe('Server Error');
+    });
+
+    test('stringifies non-string text bodies without error', async () => {
+      setupMockFetch({ value: 123 }, 200, 'text/plain');
+      const fetchModule = await import('cross-fetch');
+      const response = await fetchModule.default('https://app.bentonow.com/api/v1/test');
+      const text = await response.text();
+      expect(text).toBe('[object Object]');
+    });
+
+    test('uses queued responses and falls back to last entry', async () => {
+      setupMockFetch([
+        { body: { value: 'first' } },
+        { body: { value: 'second' } },
+      ]);
+      const fetchModule = await import('cross-fetch');
+      const fetchFn = fetchModule.default;
+
+      const first = await fetchFn('https://app.bentonow.com/api/v1/test');
+      const second = await fetchFn('https://app.bentonow.com/api/v1/test');
+      const third = await fetchFn('https://app.bentonow.com/api/v1/test');
+
+      expect(await first.json()).toEqual({ value: 'first' });
+      expect(await second.json()).toEqual({ value: 'second' });
+      expect(await third.json()).toEqual({ value: 'second' });
     });
   });
 });

--- a/__tests__/helpers/mockFetch.ts
+++ b/__tests__/helpers/mockFetch.ts
@@ -1,28 +1,83 @@
 import { mock } from 'bun:test';
 
-// Store the last URL and method for verification in tests
+type MockResponseEntry = {
+  body: any;
+  status?: number;
+  contentType?: string;
+};
+
+const normalizeEntry = (
+  value: MockResponseEntry | any,
+  defaultStatus: number,
+  defaultContentType: string
+): MockResponseEntry => {
+  if (value && typeof value === 'object' && 'body' in value) {
+    return {
+      body: value.body,
+      status: value.status ?? defaultStatus,
+      contentType: value.contentType ?? defaultContentType,
+    };
+  }
+
+  return {
+    body: value,
+    status: defaultStatus,
+    contentType: defaultContentType,
+  };
+};
+
+// Store the last URL, method, and signal for verification in tests
 export let lastFetchUrl: string | null = null;
 export let lastFetchMethod: string | null = null;
+export let lastFetchSignal: AbortSignal | null = null;
 
-export const setupMockFetch = (response: any, status = 200, contentType = 'application/json') => {
+export const setupMockFetch = (
+  response: any | MockResponseEntry[],
+  status = 200,
+  contentType = 'application/json'
+) => {
+  lastFetchUrl = null;
+  lastFetchMethod = null;
+  lastFetchSignal = null;
+
+  const isQueue = Array.isArray(response);
+  const queue = isQueue
+    ? (response as MockResponseEntry[]).map((entry) => normalizeEntry(entry, 200, 'application/json'))
+    : null;
+  const singleEntry = normalizeEntry(response, status, contentType);
+  const fallbackEntry = queue && queue.length > 0 ? queue[queue.length - 1] : singleEntry;
+
   mock.module('cross-fetch', () => ({
-    default: (url: string, options: RequestInit) => {
-      // Capture URL and method for test verification
+    default: (url: string, options: RequestInit = {}) => {
+      // Capture URL, method, and AbortSignal for test verification
       lastFetchUrl = url;
-      lastFetchMethod = options?.method || 'GET';
+      lastFetchMethod = options.method || 'GET';
+      lastFetchSignal = options.signal ?? null;
+
+      const entry = queue ? queue.shift() ?? fallbackEntry : singleEntry;
+      const currentStatus = entry.status ?? status;
+      const currentContentType = entry.contentType ?? contentType;
+      const body = entry.body;
 
       return Promise.resolve({
-        status,
-        ok: status >= 200 && status < 300,
-        json: () => Promise.resolve(response),
+        status: currentStatus,
+        ok: currentStatus >= 200 && currentStatus < 300,
+        json: () => Promise.resolve(body),
         text: () => {
-          if (contentType === 'text/plain') {
-            return Promise.resolve(response.error);
+          if (currentContentType === 'text/plain') {
+            if (typeof body === 'string') {
+              return Promise.resolve(body);
+            }
+            if (body?.error) {
+              return Promise.resolve(body.error);
+            }
+            return Promise.resolve(String(body));
           }
-          return Promise.resolve(JSON.stringify(response));
+
+          return Promise.resolve(JSON.stringify(body));
         },
         headers: new Headers({
-          'Content-Type': contentType,
+          'Content-Type': currentContentType,
         }),
       });
     },

--- a/__tests__/sequences/sequences.test.ts
+++ b/__tests__/sequences/sequences.test.ts
@@ -43,11 +43,10 @@ describe('BentoSequences', () => {
 
       const result = await analytics.V1.Sequences.getSequences();
 
-      expect(result).not.toBeNull();
       expect(result).toHaveLength(2);
-      expect(result![0].attributes.name).toBe('Onboarding Sequence');
-      expect(result![0].attributes.email_templates).toHaveLength(2);
-      expect(result![1].attributes.name).toBe('Re-engagement Sequence');
+      expect(result[0].attributes.name).toBe('Onboarding Sequence');
+      expect(result[0].attributes.email_templates).toHaveLength(2);
+      expect(result[1].attributes.name).toBe('Re-engagement Sequence');
     });
 
     test('uses correct endpoint for GET request', async () => {
@@ -59,20 +58,20 @@ describe('BentoSequences', () => {
       expect(lastFetchMethod).toBe('GET');
     });
 
-    test('returns null when response is empty object', async () => {
+    test('returns empty array when response is empty object', async () => {
       setupMockFetch({});
 
       const result = await analytics.V1.Sequences.getSequences();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
-    test('returns null when response has no data', async () => {
+    test('returns empty array when response has no data', async () => {
       setupMockFetch({ data: null });
 
       const result = await analytics.V1.Sequences.getSequences();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
     test('returns empty array when no sequences exist', async () => {
@@ -80,7 +79,6 @@ describe('BentoSequences', () => {
 
       const result = await analytics.V1.Sequences.getSequences();
 
-      expect(result).not.toBeNull();
       expect(result).toHaveLength(0);
     });
 
@@ -103,8 +101,7 @@ describe('BentoSequences', () => {
 
       const result = await analytics.V1.Sequences.getSequences();
 
-      expect(result).not.toBeNull();
-      expect(result![0].attributes.email_templates).toHaveLength(0);
+      expect(result[0].attributes.email_templates).toHaveLength(0);
     });
 
     test('handles server error gracefully', async () => {

--- a/__tests__/versions/v1/upsert.test.ts
+++ b/__tests__/versions/v1/upsert.test.ts
@@ -2,6 +2,7 @@ import { expect, test, describe, beforeEach } from 'bun:test';
 import { Analytics } from '../../../src';
 import { mockOptions } from '../../helpers/mockClient';
 import { setupMockFetch } from '../../helpers/mockFetch';
+import { EntityType } from '../../../src/sdk/enums';
 
 describe('BentoAPIV1 - upsertSubscriber', () => {
   let analytics: Analytics;
@@ -10,8 +11,28 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
     analytics = new Analytics(mockOptions);
   });
 
-  test('successfully queues subscriber for import', async () => {
-    setupMockFetch({ results: 1 });
+  test('successfully creates new subscriber', async () => {
+    const mockSubscriber = {
+      data: {
+        id: 'new-sub-1',
+        type: EntityType.VISITORS,
+        attributes: {
+          uuid: 'uuid-123',
+          email: 'new@example.com',
+          fields: {
+            firstName: 'John',
+            lastName: 'Doe',
+          },
+          cached_tag_ids: [],
+          unsubscribed_at: null,
+        },
+      },
+    };
+
+    setupMockFetch([
+      { body: { results: 1 } },
+      { body: mockSubscriber },
+    ]);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'new@example.com',
@@ -21,12 +42,34 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       },
     });
 
-    // Now returns the number of subscribers queued (1)
-    expect(result).toBe(1);
+    expect(result).not.toBeNull();
+    expect(result?.attributes.email).toBe('new@example.com');
+    expect(result?.attributes.fields?.firstName).toBe('John');
   });
 
-  test('successfully queues existing subscriber for update', async () => {
-    setupMockFetch({ results: 1 });
+  test('successfully updates existing subscriber', async () => {
+    const mockSubscriber = {
+      data: {
+        id: 'existing-sub-1',
+        type: EntityType.VISITORS,
+        attributes: {
+          uuid: 'uuid-456',
+          email: 'existing@example.com',
+          fields: {
+            firstName: 'Jane',
+            lastName: 'Smith',
+            company: 'Updated Corp',
+          },
+          cached_tag_ids: ['existing-tag'],
+          unsubscribed_at: null,
+        },
+      },
+    };
+
+    setupMockFetch([
+      { body: { results: 1 } },
+      { body: mockSubscriber },
+    ]);
 
     const result = await analytics.V1.upsertSubscriber({
       email: 'existing@example.com',
@@ -37,11 +80,12 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
       },
     });
 
-    expect(result).toBe(1);
+    expect(result).not.toBeNull();
+    expect(result?.attributes.fields?.company).toBe('Updated Corp');
   });
 
   test('handles error during import', async () => {
-    setupMockFetch({ error: 'Import failed' }, 500);
+    setupMockFetch([{ body: { error: 'Import failed' }, status: 500 }]);
 
     await expect(
       analytics.V1.upsertSubscriber({
@@ -53,68 +97,35 @@ describe('BentoAPIV1 - upsertSubscriber', () => {
     ).rejects.toThrow();
   });
 
-  test('successfully queues subscriber with tags', async () => {
-    setupMockFetch({ results: 1 });
+  test('handles error during subscriber fetch', async () => {
+    setupMockFetch([
+      { body: { results: 1 } },
+      { body: { error: 'Fetch failed' }, status: 500 },
+    ]);
+
+    await expect(
+      analytics.V1.upsertSubscriber({
+        email: 'test@example.com',
+        fields: {
+          firstName: 'Test',
+        },
+      })
+    ).rejects.toThrow();
+  });
+
+  test('handles subscriber not found after import', async () => {
+    setupMockFetch([
+      { body: { results: 1 } },
+      { body: { data: null } },
+    ]);
 
     const result = await analytics.V1.upsertSubscriber({
-      email: 'tagged@example.com',
+      email: 'missing@example.com',
       fields: {
-        firstName: 'Tagged',
+        firstName: 'Missing',
       },
-      tags: 'tag-1,tag-2',
     });
 
-    expect(result).toBe(1);
-  });
-
-  test('successfully queues subscriber with remove_tags', async () => {
-    setupMockFetch({ results: 1 });
-
-    const result = await analytics.V1.upsertSubscriber({
-      email: 'removed-tags@example.com',
-      fields: {
-        firstName: 'Removed',
-      },
-      remove_tags: 'old-tag',
-    });
-
-    expect(result).toBe(1);
-  });
-
-  test('successfully queues subscriber with both tags and remove_tags', async () => {
-    setupMockFetch({ results: 1 });
-
-    const result = await analytics.V1.upsertSubscriber({
-      email: 'both-tags@example.com',
-      fields: {
-        firstName: 'Both',
-      },
-      tags: 'new-tag',
-      remove_tags: 'old-tag',
-    });
-
-    expect(result).toBe(1);
-  });
-
-  test('successfully queues subscriber with empty fields', async () => {
-    setupMockFetch({ results: 1 });
-
-    const result = await analytics.V1.upsertSubscriber({
-      email: 'minimal@example.com',
-      fields: {},
-    });
-
-    expect(result).toBe(1);
-  });
-
-  test('returns 0 when no subscribers are queued', async () => {
-    setupMockFetch({ results: 0 });
-
-    const result = await analytics.V1.upsertSubscriber({
-      email: 'test@example.com',
-      fields: {},
-    });
-
-    expect(result).toBe(0);
+    expect(result).toBeNull();
   });
 });

--- a/__tests__/workflows/workflows.test.ts
+++ b/__tests__/workflows/workflows.test.ts
@@ -43,11 +43,10 @@ describe('BentoWorkflows', () => {
 
       const result = await analytics.V1.Workflows.getWorkflows();
 
-      expect(result).not.toBeNull();
       expect(result).toHaveLength(2);
-      expect(result![0].attributes.name).toBe('Welcome Workflow');
-      expect(result![0].attributes.email_templates).toHaveLength(2);
-      expect(result![1].attributes.name).toBe('Abandoned Cart Workflow');
+      expect(result[0].attributes.name).toBe('Welcome Workflow');
+      expect(result[0].attributes.email_templates).toHaveLength(2);
+      expect(result[1].attributes.name).toBe('Abandoned Cart Workflow');
     });
 
     test('uses correct endpoint for GET request', async () => {
@@ -59,20 +58,20 @@ describe('BentoWorkflows', () => {
       expect(lastFetchMethod).toBe('GET');
     });
 
-    test('returns null when response is empty object', async () => {
+    test('returns empty array when response is empty object', async () => {
       setupMockFetch({});
 
       const result = await analytics.V1.Workflows.getWorkflows();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
-    test('returns null when response has no data', async () => {
+    test('returns empty array when response has no data', async () => {
       setupMockFetch({ data: null });
 
       const result = await analytics.V1.Workflows.getWorkflows();
 
-      expect(result).toBeNull();
+      expect(result).toEqual([]);
     });
 
     test('returns empty array when no workflows exist', async () => {
@@ -80,7 +79,6 @@ describe('BentoWorkflows', () => {
 
       const result = await analytics.V1.Workflows.getWorkflows();
 
-      expect(result).not.toBeNull();
       expect(result).toHaveLength(0);
     });
 
@@ -103,8 +101,7 @@ describe('BentoWorkflows', () => {
 
       const result = await analytics.V1.Workflows.getWorkflows();
 
-      expect(result).not.toBeNull();
-      expect(result![0].attributes.email_templates).toHaveLength(0);
+      expect(result[0].attributes.email_templates).toHaveLength(0);
     });
 
     test('handles server error gracefully', async () => {

--- a/src/sdk/batch/index.ts
+++ b/src/sdk/batch/index.ts
@@ -54,7 +54,8 @@ export class BentoBatch<S, E extends string> {
       `${this._url}/subscribers`,
       {
         subscribers: parameters.subscribers,
-      }
+      },
+      { timeout: null }
     );
 
     return result.results;
@@ -80,9 +81,13 @@ export class BentoBatch<S, E extends string> {
       throw new TooManyEventsError(`You must send between 1 and 1,000 events.`);
     }
 
-    const result = await this._client.post<BatchImportEventsResponse>(`${this._url}/events`, {
-      events: parameters.events,
-    });
+    const result = await this._client.post<BatchImportEventsResponse>(
+      `${this._url}/events`,
+      {
+        events: parameters.events,
+      },
+      { timeout: null }
+    );
 
     return result.results;
   }

--- a/src/sdk/sequences/index.ts
+++ b/src/sdk/sequences/index.ts
@@ -10,12 +10,12 @@ export class BentoSequences {
   /**
    * Returns all of the sequences for the site, including their email templates.
    *
-   * @returns Promise\<Sequence[] | null\>
+   * @returns Promise\<Sequence[]\>
    */
-  public async getSequences(): Promise<Sequence[] | null> {
+  public async getSequences(): Promise<Sequence[]> {
     const result = await this._client.get<DataResponse<Sequence[]>>(this._url);
 
-    if (Object.keys(result).length === 0 || !result.data) return null;
-    return result.data;
+    if (!result || Object.keys(result).length === 0) return [];
+    return result.data ?? [];
   }
 }

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -10,12 +10,12 @@ export class BentoWorkflows {
   /**
    * Returns all of the workflows for the site, including their email templates.
    *
-   * @returns Promise\<Workflow[] | null\>
+   * @returns Promise\<Workflow[]\>
    */
-  public async getWorkflows(): Promise<Workflow[] | null> {
+  public async getWorkflows(): Promise<Workflow[]> {
     const result = await this._client.get<DataResponse<Workflow[]>>(this._url);
 
-    if (Object.keys(result).length === 0 || !result.data) return null;
-    return result.data;
+    if (!result || Object.keys(result).length === 0) return [];
+    return result.data ?? [];
   }
 }


### PR DESCRIPTION
## Changes

- Added optional timeout parameter to HTTP methods
- Enhanced request configuration with RequestOptions interface
- Improved test coverage for batch event imports and mock fetch
- Updated documentation for upsertSubscriber method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces per-request timeout control and updates subscriber upsert behavior, with supporting tests and docs.
> 
> - **Client:** `get`, `post`, `patch` now accept `RequestOptions` with `timeout`; `_fetchWithTimeout` supports `timeout: null` (no AbortSignal) and surfaces JSON parse errors clearly
> - **Batch:** `importSubscribers` and `importEvents` call the client with `{ timeout: null }` to avoid timeouts for long-running imports
> - **V1 API:** `upsertSubscriber` now queues an import then fetches and returns the `Subscriber` (or `null`); README updated accordingly
> - **Sequences/Workflows:** `getSequences`/`getWorkflows` now return `[]` for empty responses instead of `null`
> - **Tests/Mocks:** Add signal assertions, mock fetch queueing and text/plain handling, new tests for batch imports and timeout behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c060b5a49b312292de5b05607df55c0ba0e2010c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->