### PR TITLE
fix(sdk): Correct typo in batch email documentation comment

### DIFF
--- a/src/sdk/batch/index.ts
+++ b/src/sdk/batch/index.ts
@@ -99,7 +99,7 @@ export class BentoBatch<S, E extends string> {
    * Each email must have a `to` address, a `from` address, a `subject`, an `html_body`
    * and `transactional: true`.
    * In addition you can add a `personalizations` object to provide
-   * liquid tsags that will be injected into the email.
+   * liquid tags that will be injected into the email.
    *
    * Returns the number of events that were imported.
    *


### PR DESCRIPTION
Resolve a minor typo in the documentation comment for batch email
functionality, changing "tsags" to "tags" to improve readability and
accuracy of the code comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor documentation correction only; no runtime behavior changes.
> 
> - Fixes a typo in the `sendTransactionalEmails` JSDoc, changing "liquid tsags" to "liquid tags` in `src/sdk/batch/index.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 313c05c176684c9ebc03727f5a38c2236aca68e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->