### PR TITLE
feat(sequences/workflows): add optional pagination to fetch APIs

### DIFF
--- a/__tests__/client/client.test.ts
+++ b/__tests__/client/client.test.ts
@@ -1,7 +1,12 @@
 import { expect, test, describe, beforeEach, afterEach, mock } from 'bun:test';
 import { Analytics } from '../../src';
 import { mockOptions } from '../helpers/mockClient';
-import { setupMockFetch, lastFetchSignal, resetMockFetchTracking } from '../helpers/mockFetch';
+import {
+  setupMockFetch,
+  lastFetchSignal,
+  lastFetchUrl,
+  resetMockFetchTracking,
+} from '../helpers/mockFetch';
 import { NotAuthorizedError, RateLimitedError, RequestTimeoutError } from '../../src';
 
 describe('BentoClient', () => {
@@ -212,6 +217,17 @@ describe('BentoClient', () => {
       expect(url.searchParams.get('site_uuid')).not.toBe('null');
 
       // Verify site_uuid is properly set
+      expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
+    });
+
+    test('omits undefined query parameters when forwarding SDK options', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Sequences.getSequences({ page: undefined });
+
+      expect(lastFetchUrl).not.toBeNull();
+      const url = new URL(lastFetchUrl!);
+      expect(url.searchParams.has('page')).toBe(false);
       expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
     });
 

--- a/__tests__/sequences/sequences.test.ts
+++ b/__tests__/sequences/sequences.test.ts
@@ -61,6 +61,17 @@ describe('BentoSequences', () => {
       expect(lastFetchMethod).toBe('GET');
     });
 
+    test('passes pagination parameters in query string', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Sequences.getSequences({ page: 5 });
+
+      expect(lastFetchUrl).toContain('/fetch/sequences');
+      const url = new URL(lastFetchUrl!);
+      expect(url.searchParams.get('page')).toBe('5');
+      expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
+    });
+
     test('returns empty array when response is empty object', async () => {
       setupMockFetch({});
 

--- a/__tests__/workflows/workflows.test.ts
+++ b/__tests__/workflows/workflows.test.ts
@@ -61,6 +61,17 @@ describe('BentoWorkflows', () => {
       expect(lastFetchMethod).toBe('GET');
     });
 
+    test('passes pagination parameters in query string', async () => {
+      setupMockFetch({ data: [] });
+
+      await analytics.V1.Workflows.getWorkflows({ page: 3 });
+
+      expect(lastFetchUrl).toContain('/fetch/workflows');
+      const url = new URL(lastFetchUrl!);
+      expect(url.searchParams.get('page')).toBe('3');
+      expect(url.searchParams.get('site_uuid')).toBe(mockOptions.siteUuid);
+    });
+
     test('returns empty array when response is empty object', async () => {
       setupMockFetch({});
 

--- a/src/sdk/client/index.ts
+++ b/src/sdk/client/index.ts
@@ -255,6 +255,7 @@ export class BentoClient {
 
     const queryParameters = new URLSearchParams();
     for (const [key, value] of Object.entries(body)) {
+      if (value === undefined || value === null) continue;
       queryParameters.append(key, String(value));
     }
 

--- a/src/sdk/sequences/index.ts
+++ b/src/sdk/sequences/index.ts
@@ -1,7 +1,7 @@
 import type { BentoClient } from '../client';
 import type { DataResponse } from '../client/types';
 import type { EmailTemplate } from '../email-templates/types';
-import type { CreateSequenceEmailParameters, Sequence } from './types';
+import type { CreateSequenceEmailParameters, GetSequencesParameters, Sequence } from './types';
 
 export class BentoSequences {
   private readonly _url = '/fetch/sequences';
@@ -11,10 +11,11 @@ export class BentoSequences {
   /**
    * Returns all of the sequences for the site, including their email templates.
    *
+   * @param parameters Optional pagination parameters (e.g., { page: 2 })
    * @returns Promise\<Sequence[]\>
    */
-  public async getSequences(): Promise<Sequence[]> {
-    const result = await this._client.get<DataResponse<Sequence[]>>(this._url);
+  public async getSequences(parameters: GetSequencesParameters = {}): Promise<Sequence[]> {
+    const result = await this._client.get<DataResponse<Sequence[]>>(this._url, parameters);
 
     if (!result || Object.keys(result).length === 0) return [];
     return result.data ?? [];

--- a/src/sdk/sequences/types.ts
+++ b/src/sdk/sequences/types.ts
@@ -23,6 +23,10 @@ export type Sequence = BaseEntity<SequenceAttributes>;
 
 export type SequenceDelayInterval = 'minutes' | 'hours' | 'days' | 'months';
 
+export type GetSequencesParameters = {
+  page?: number;
+};
+
 export type CreateSequenceEmailParameters = {
   subject: string;
   html: string;

--- a/src/sdk/workflows/index.ts
+++ b/src/sdk/workflows/index.ts
@@ -1,6 +1,6 @@
 import type { BentoClient } from '../client';
 import type { DataResponse } from '../client/types';
-import type { Workflow } from './types';
+import type { GetWorkflowsParameters, Workflow } from './types';
 
 export class BentoWorkflows {
   private readonly _url = '/fetch/workflows';
@@ -10,10 +10,11 @@ export class BentoWorkflows {
   /**
    * Returns all of the workflows for the site, including their email templates.
    *
+   * @param parameters Optional pagination parameters (e.g., { page: 2 })
    * @returns Promise\<Workflow[]\>
    */
-  public async getWorkflows(): Promise<Workflow[]> {
-    const result = await this._client.get<DataResponse<Workflow[]>>(this._url);
+  public async getWorkflows(parameters: GetWorkflowsParameters = {}): Promise<Workflow[]> {
+    const result = await this._client.get<DataResponse<Workflow[]>>(this._url, parameters);
 
     if (!result || Object.keys(result).length === 0) return [];
     return result.data ?? [];

--- a/src/sdk/workflows/types.ts
+++ b/src/sdk/workflows/types.ts
@@ -19,3 +19,7 @@ export type WorkflowAttributes = {
 };
 
 export type Workflow = BaseEntity<WorkflowAttributes>;
+
+export type GetWorkflowsParameters = {
+  page?: number;
+};


### PR DESCRIPTION
Add optional pagination support to Sequences and Workflows fetch
endpoints by introducing GetSequencesParameters and
GetWorkflowsParameters types with a page?: number field. Update the
BentoSequences.getSequences and BentoWorkflows.getWorkflows methods to
accept an optional parameters object and forward it to the client's GET
call. Adjust imports and types accordingly.

Also expand README docs for Sequences: add a higher-level description,
show example usage with Analytics client, demonstrate passing { page }
for pagination, and enrich example response and createSequenceEmail
documentation to better reflect real-world fields and links to API
docs.

This enables callers to paginate large installs and documents usage in
the SDK README.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ziptied/bento-node-sdk/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backwards-compatible, additive API changes plus a small query-string serialization tweak; risk is limited to GET request parameter formatting and is covered by new tests.
> 
> **Overview**
> Adds optional pagination support to `V1.Sequences.getSequences` and `V1.Workflows.getWorkflows` by accepting `{ page? }` parameter objects and forwarding them to the underlying GET calls.
> 
> Updates the shared query-string builder to **omit `undefined`/`null` values** (preventing `page=undefined`) and adds/extends tests to assert pagination parameters are encoded correctly and skipped when unset.
> 
> Expands `README.md` docs for Sequences/Workflows/Email Templates with clearer endpoint references, updated `Analytics`-based examples, and an `updateSequenceEmail` example via `EmailTemplates.updateEmailTemplate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cea3e268d37537d5e7be3b36481a50caad55bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Added optional pagination support to `analytics.V1.Sequences.getSequences` and `analytics.V1.Workflows.getWorkflows` by introducing new parameter types with a `page?: number` field. The implementation is backwards-compatible as both methods use default empty objects when no parameters are provided.

- Introduced `GetSequencesParameters` and `GetWorkflowsParameters` types with optional `page` field
- Updated method signatures to accept optional parameters and forward them to the underlying client GET calls
- Added test coverage verifying pagination parameters are correctly passed in query strings
- Expanded README documentation with improved examples, API endpoint references, and usage patterns for the Analytics client
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are backwards-compatible (optional parameters with defaults), well-tested (new pagination tests added), and follow existing patterns in the codebase. The implementation correctly forwards parameters to the client's query string builder, and documentation has been enhanced to reflect the new capabilities.
- No files require special attention

<sub>Last reviewed commit: 3410cbe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->