### PR TITLE
feat: add status field to workflow attributes

### DIFF
--- a/__tests__/workflows/workflows.test.ts
+++ b/__tests__/workflows/workflows.test.ts
@@ -23,6 +23,7 @@ describe('BentoWorkflows', () => {
             type: EntityType.WORKFLOWS,
             attributes: {
               name: 'Welcome Workflow',
+              status: 'live',
               created_at: '2024-01-01T00:00:00Z',
               email_templates: [
                 { id: 1, subject: 'Welcome!', stats: { opened: 150, clicked: 75 } },
@@ -35,6 +36,7 @@ describe('BentoWorkflows', () => {
             type: EntityType.WORKFLOWS,
             attributes: {
               name: 'Abandoned Cart Workflow',
+              status: 'draft',
               created_at: '2024-02-01T00:00:00Z',
               email_templates: [{ id: 3, subject: 'You left something behind', stats: null }],
             },
@@ -48,8 +50,10 @@ describe('BentoWorkflows', () => {
 
       expect(result).toHaveLength(2);
       expect(result[0].attributes.name).toBe('Welcome Workflow');
+      expect(result[0].attributes.status).toBe('live');
       expect(result[0].attributes.email_templates).toHaveLength(2);
       expect(result[1].attributes.name).toBe('Abandoned Cart Workflow');
+      expect(result[1].attributes.status).toBe('draft');
     });
 
     test('uses correct endpoint for GET request', async () => {
@@ -104,6 +108,7 @@ describe('BentoWorkflows', () => {
             type: EntityType.WORKFLOWS,
             attributes: {
               name: 'Empty Workflow',
+              status: 'live',
               created_at: '2024-01-01T00:00:00Z',
               email_templates: [],
             },

--- a/src/sdk/workflows/types.ts
+++ b/src/sdk/workflows/types.ts
@@ -14,6 +14,7 @@ export type WorkflowEmailTemplate = {
  */
 export type WorkflowAttributes = {
   name: string;
+  status: 'live' | 'draft';
   created_at: string;
   email_templates: WorkflowEmailTemplate[];
 };


### PR DESCRIPTION
Add status field to WorkflowAttributes type to track
workflow state as either 'live' or 'draft'. Update all
workflow test fixtures to include the new status field
and add assertions to verify status values are correctly
returned from the API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ziptied/bento-node-sdk/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `status` field (`'live' | 'draft'`) to the `WorkflowAttributes` type and updates all workflow test fixtures with corresponding status values and assertions. The change is small, focused, and consistent across the type definition and tests.

- `WorkflowAttributes` gains a required `status: 'live' | 'draft'` union — if the API doesn't guarantee this field on all existing workflow records, it should be marked optional (`status?`) to avoid misleading callers with a non-nullable type contract
- The "handles workflow with empty email templates" test adds `status: 'live'` to its fixture but never asserts on it, leaving a minor coverage gap compared to the other tests
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge; changes are minimal and well-tested, with one minor question about whether `status` should be optional.
- The diff is small and the test coverage is good. The only open question is whether the Bento API guarantees `status` on all workflow responses — if it doesn't, the required field could mislead consumers. This is not a runtime error in the SDK itself (types are erased at runtime), but it is a correctness concern for TypeScript consumers.
- `src/sdk/workflows/types.ts` — verify the API always returns `status` before keeping the field required.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `__tests__/workflows/workflows.test.ts`, line 103-124 ([link](https://github.com/ziptied/bento-node-sdk/blob/cdcc3187a80091adcad92ec81946e1440c2880eb/__tests__/workflows/workflows.test.ts#L103-L124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing status assertion in test fixture**

   The `status: 'live'` field was added to the fixture for this test, but no assertion is made against `result[0].attributes.status`. Since the primary goal of this PR is to verify the `status` field is returned correctly, it would be consistent to assert on it here as well.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: cdcc318</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->